### PR TITLE
Fix project save and display issues

### DIFF
--- a/my-portfolio/src/app/api/projects/attach/route.ts
+++ b/my-portfolio/src/app/api/projects/attach/route.ts
@@ -1,17 +1,19 @@
 import { NextRequest, NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "fs";
+import type { Attachment, ProjectData } from "@/utils/projectData";
 
 const PROJECTS_PATH = path.join(process.cwd(), "src", "data", "projects.json");
 
 export async function POST(req: NextRequest) {
-  const { projectSlug, file } = await req.json();
+  const { projectSlug, file }: { projectSlug: string; file: Attachment } =
+    await req.json();
 
   try {
     const fileData = await fs.readFile(PROJECTS_PATH, "utf-8");
-    const projects = JSON.parse(fileData);
+    const projects: ProjectData[] = JSON.parse(fileData);
 
-    const project = projects.find((p: any) => p.slug === projectSlug);
+    const project = projects.find((p) => p.slug === projectSlug);
     if (!project)
       return NextResponse.json({ error: "Project not found" }, { status: 404 });
 

--- a/my-portfolio/src/app/api/projects/deleteAttachment/route.ts
+++ b/my-portfolio/src/app/api/projects/deleteAttachment/route.ts
@@ -2,17 +2,19 @@ import { NextRequest, NextResponse } from "next/server";
 import path from "path";
 import { promises as fs } from "fs";
 import { del } from "@vercel/blob";
+import type { Attachment, ProjectData } from "@/utils/projectData";
 
 const PROJECTS_PATH = path.join(process.cwd(), "src", "data", "projects.json");
 
 export async function POST(req: NextRequest) {
-  const { projectSlug, pathname } = await req.json();
+  const { projectSlug, pathname }: { projectSlug: string; pathname: string } =
+    await req.json();
 
   try {
     const fileData = await fs.readFile(PROJECTS_PATH, "utf-8");
-    const projects = JSON.parse(fileData);
+    const projects: ProjectData[] = JSON.parse(fileData);
 
-    const project = projects.find((p: any) => p.slug === projectSlug);
+    const project = projects.find((p) => p.slug === projectSlug);
     if (!project || !project.attachments) {
       return NextResponse.json(
         { error: "Project or attachments not found" },
@@ -22,7 +24,7 @@ export async function POST(req: NextRequest) {
 
     // Filter out the file
     project.attachments = project.attachments.filter(
-      (f: any) => f.pathname !== pathname
+      (f: Attachment) => f.pathname !== pathname
     );
     await fs.writeFile(PROJECTS_PATH, JSON.stringify(projects, null, 2));
 

--- a/my-portfolio/src/app/api/projects/route.ts
+++ b/my-portfolio/src/app/api/projects/route.ts
@@ -1,0 +1,43 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getAllProjects, saveProjects, type ProjectData } from "@/utils/projectData";
+
+function createSlug(title: string, existing: Set<string>): string {
+  const base = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+  let slug = base;
+  let i = 1;
+  while (existing.has(slug)) {
+    slug = `${base}-${i++}`;
+  }
+  return slug;
+}
+
+export async function GET() {
+  const projects = getAllProjects();
+  return NextResponse.json(projects);
+}
+
+export async function POST(req: NextRequest) {
+  const { title, description, imageUrl } = await req.json();
+  if (!title || !description) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+
+  const projects = getAllProjects();
+  const slug = createSlug(title, new Set(projects.map((p) => p.slug)));
+
+  const newProject: ProjectData = {
+    title,
+    description,
+    image: imageUrl,
+    slug,
+    attachments: [],
+  };
+
+  projects.push(newProject);
+  saveProjects(projects);
+
+  return NextResponse.json(newProject, { status: 201 });
+}

--- a/my-portfolio/src/app/projects/ProjectsClient.tsx
+++ b/my-portfolio/src/app/projects/ProjectsClient.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ProjectCard from "@/components/ProjectCard";
+import NewProjectModal from "@/components/NewProjectModal";
+import styles from "@/styles/pages/Projects.module.css";
+import { isAdmin } from "@/utils/auth";
+import type { ProjectData } from "@/utils/projectData";
+
+export default function ProjectsClient() {
+  const [projects, setProjects] = useState<ProjectData[]>([]);
+  const [showModal, setShowModal] = useState(false);
+  const admin = isAdmin();
+
+  const loadProjects = async () => {
+    const res = await fetch("/api/projects");
+    if (res.ok) {
+      setProjects(await res.json());
+    }
+  };
+
+  useEffect(() => {
+    loadProjects();
+  }, []);
+
+  const handleAddProject = () => {
+    loadProjects();
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
+  };
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.title}>Projects</h1>
+      {admin && (
+        <>
+          <button onClick={() => setShowModal(true)}>Add New Project</button>
+          {showModal && (
+            <NewProjectModal
+              onClose={handleCloseModal}
+              onAdd={handleAddProject}
+            />
+          )}
+        </>
+      )}
+      <div className={styles.grid}>
+        {projects.map((p) => (
+          <ProjectCard key={p.slug} project={p} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/my-portfolio/src/app/projects/page.tsx
+++ b/my-portfolio/src/app/projects/page.tsx
@@ -1,54 +1,9 @@
-"use client";
+import ProjectsClient from "./ProjectsClient";
 
-import { useEffect, useState } from "react";
-import ProjectCard from "@/components/ProjectCard";
-import NewProjectModal from "@/components/NewProjectModal";
-import styles from "@/styles/pages/Projects.module.css";
-import { isAdmin } from "@/utils/auth";
-import type { ProjectData } from "@/utils/projectData";
+export const metadata = {
+  title: "Projects",
+};
 
 export default function ProjectsPage() {
-  const [projects, setProjects] = useState<ProjectData[]>([]);
-  const [showModal, setShowModal] = useState(false);
-  const admin = isAdmin();
-
-  const loadProjects = async () => {
-    const res = await fetch("/api/projects");
-    if (res.ok) {
-      setProjects(await res.json());
-    }
-  };
-
-  useEffect(() => {
-    loadProjects();
-  }, []);
-
-  const handleAddProject = () => {
-    loadProjects();
-  };
-
-  const handleCloseModal = () => {
-    setShowModal(false);
-  };
-
-  return (
-    <div className={styles.container}>
-      {admin && (
-        <>
-          <button onClick={() => setShowModal(true)}>Add New Project</button>
-          {showModal && (
-            <NewProjectModal
-              onClose={handleCloseModal}
-              onAdd={handleAddProject}
-            />
-          )}
-        </>
-      )}
-      <div className={styles.grid}>
-        {projects.map((p) => (
-          <ProjectCard key={p.slug} project={p} />
-        ))}
-      </div>
-    </div>
-  );
+  return <ProjectsClient />;
 }

--- a/my-portfolio/src/components/Header.tsx
+++ b/my-portfolio/src/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import LoginToggle from "@/components/LoginToggle";
+import Link from "next/link";
 
 export default function Header() {
   return (
@@ -13,12 +14,12 @@ export default function Header() {
     >
       <LoginToggle />
       <nav style={{ textAlign: "center" }}>
-        <a href="/" style={{ margin: "0 1rem" }}>
+        <Link href="/" style={{ margin: "0 1rem" }}>
           Home
-        </a>
-        <a href="/projects" style={{ margin: "0 1rem" }}>
+        </Link>
+        <Link href="/projects" style={{ margin: "0 1rem" }}>
           Projects
-        </a>
+        </Link>
       </nav>
     </header>
   );

--- a/my-portfolio/src/styles/pages/Projects.module.css
+++ b/my-portfolio/src/styles/pages/Projects.module.css
@@ -2,6 +2,11 @@
   padding: 2rem;
 }
 
+.title {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
 .grid {
   display: grid;
   gap: 2rem;

--- a/my-portfolio/src/utils/projectData.ts
+++ b/my-portfolio/src/utils/projectData.ts
@@ -3,12 +3,19 @@ import path from "path";
 
 const dataFilePath = path.join(process.cwd(), "src/data/projects.json");
 
+export type Attachment = {
+  name: string;
+  url: string;
+  contentType: string;
+  pathname: string;
+};
+
 export type ProjectData = {
   slug: string;
   title: string;
   description: string;
   image?: string;
-  attachments?: string[];
+  attachments?: Attachment[];
 };
 
 export function getAllProjects(): ProjectData[] {


### PR DESCRIPTION
## Summary
- add projects API route to read/write projects.json with slug generation
- show project listings with title via new client component
- replace anchor links with Next.js `Link` and tighten attachment typings

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68927b5cd130832b9a5fd1754eca74d6